### PR TITLE
Added convert to SCSS (SASS v3) command

### DIFF
--- a/bundle.rb
+++ b/bundle.rb
@@ -156,6 +156,7 @@ bundle do |bundle|
     end
     main_menu.command t(:compile_sass)
     main_menu.command t(:convert_css_to_sass)
+    main_menu.command t(:convert_css_to_scss)
     main_menu.command t(:insert_color)
   end
 end

--- a/commands/convert_css_to_scss.rb
+++ b/commands/convert_css_to_scss.rb
@@ -1,0 +1,15 @@
+require 'ruble'
+
+command t(:convert_css_to_scss) do |cmd|
+  cmd.key_binding = 'OPTION+COMMAND+C'
+  cmd.output = :replace_selection
+  cmd.input = :selection
+  cmd.invoke do |context|
+    cmd_line = "ruby -e \"require 'rubygems'; gem 'haml'; require 'sass/css'; puts Sass::CSS.new(STDIN.read).render(:scss)\""
+    IO.popen(cmd_line, 'r+') do |io|
+      io << ENV['TM_SELECTED_TEXT']
+      io.close_write
+      io.read
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,5 +14,6 @@ en:
   attribute_selector: 'Attribute Selector'
   compile_sass: 'Compile SASS'
   convert_css_to_sass: 'Convert CSS to SASS'
+  convert_css_to_scss: 'Convert CSS to SCSS'
   insert_color: 'Insert Color...'
   


### PR DESCRIPTION
Wanted to be able to use the CSS to SASS command for SASS 3, aka SCSS.

Inspired by this https://github.com/jpablobr/css2sass/blob/master/lib/css2sass/convert.rb

NOTE in order to get things working I had to run

```
sudo gem install sass
sudo gem install haml
```
